### PR TITLE
perf: Add codeowner and bump major

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 # Order is important, the last matching pattern takes the most precedence.
 
 *                                           @sasjo
+/manifests/ cloudbuild.yaml                 @tasseri


### PR DESCRIPTION
Use perf to bump major to reflect change of process.
Maybe merge this after meeting next week?

Adds me as codeowner for kubernetes and GCP related files.