### PR TITLE
feat: Track blip movement on MAJOR.MINOR version

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ name: Entry name # Required
 shortname: Short # Optional. Use only if name is too long for the radar blip
 active: true # Optional. If set to `false`, the blip is hidden on the visual radar
 blip: # A list of blip positions. Add a new entry every time the blip moves
-  - version: "1.0.0" # Required. The MAJOR.MINOR.PATCH version for the blip
+  - version: "1.0" # Required. The MAJOR.MINOR version for the blip
     ring: ASSESS # Required. The position at version, One of ADOPT, TRIAL, ASSESS, HOLD
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   A required, short description of the technology.

--- a/bin/builder.js
+++ b/bin/builder.js
@@ -168,7 +168,7 @@ function createBlip(radar, entry, htmlFile, sourceFile) {
     quadrant: 0,
     since: entry.blip[0].version,
     ring: radar.rings.indexOf(entry.blip.last().ring),
-    moved: entry.blip.last().version == radar.majorMinorVersion,
+    moved: entry.blip.last().version === radar.majorMinorVersion,
     updated: entry.blip.last().version,
     link: path.relative(radar.outputDir, htmlFile),
     active: true

--- a/bin/radarmodel.js
+++ b/bin/radarmodel.js
@@ -1,13 +1,16 @@
 const util = require('util')
 const packageVersion = require('../package.json').version
+const semver = require('semver')
 
 // Tech radar object model. Used by the builder.
 module.exports = {
   createModel: function(version) {
     let radarVersion = version || packageVersion
+    let semVersion = semver.coerce(radarVersion)
     var radar = {
       title: 'Extenda Retail Tech Radar',
       version: radarVersion,
+      majorMinorVersion: `${semVersion.major}.${semVersion.minor}`,
 
       // Quadrants in the radar visualization order.
       quadrants: [

--- a/radar/data_management/elasticsearch.yaml
+++ b/radar/data_management/elasticsearch.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Elasticsearch
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: TRIAL
 description: |
   Elasticsearch is a distributed, massivily scalable search engine.

--- a/radar/data_management/mysql.yaml
+++ b/radar/data_management/mysql.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: MySQL
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
 rationale: |

--- a/radar/infrastructure_config/ant.yaml
+++ b/radar/infrastructure_config/ant.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Apache Ant
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: HOLD
 description: |
   Apache Ant is a build tool designed to replace Make in early 2000. It is

--- a/radar/infrastructure_config/aws_lambda.yaml
+++ b/radar/infrastructure_config/aws_lambda.yaml
@@ -1,9 +1,9 @@
 version: 1
 name: AWS Lambda
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: TRIAL
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
   AWS Lambdas are serverless functions managed by AWS and automatically scaled

--- a/radar/infrastructure_config/circleci.yaml
+++ b/radar/infrastructure_config/circleci.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: CircleCI
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ASSESS
 description: |
   CircleCI is an elastic SaaS CI/CD platform. It's based on dockerized ephemeral builds

--- a/radar/infrastructure_config/docker.yaml
+++ b/radar/infrastructure_config/docker.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Docker
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   Docker is a tool designed to make it easier to create, deploy, and run applications

--- a/radar/infrastructure_config/gradle.yaml
+++ b/radar/infrastructure_config/gradle.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Gradle
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
   Gradle is a build system and dependency manager for JVM languages such as Java, Groovy and Android.

--- a/radar/infrastructure_config/grunt.yaml
+++ b/radar/infrastructure_config/grunt.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Grunt
 logo: https://gruntjs.com/img/grunt-logo.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
   The JavaScript task runner.

--- a/radar/infrastructure_config/gulp.yaml
+++ b/radar/infrastructure_config/gulp.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Gulp
 logo: https://upload.wikimedia.org/wikipedia/commons/7/72/Gulp.js_Logo.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
   Gulp is a toolkit for automating painful or time-consuming tasks in your development workflow, so you can stop messing around and build something.

--- a/radar/infrastructure_config/jenkins_aws.yaml
+++ b/radar/infrastructure_config/jenkins_aws.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Jenkins Build Farm
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   The [Jenkins Build Farm](https://jenkins.extenda.se) is a container-based, elastic build farm maintained by

--- a/radar/infrastructure_config/maven.yaml
+++ b/radar/infrastructure_config/maven.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Apache Maven
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   Apache Maven is a build tool and dependency manager for JVM languages such as

--- a/radar/infrastructure_config/saltstack.yaml
+++ b/radar/infrastructure_config/saltstack.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: SaltStack
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   SaltStack is a deployment and monitoring platform.

--- a/radar/infrastructure_config/terraform.yaml
+++ b/radar/infrastructure_config/terraform.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Terraform
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   HashiCorp Terraform allows you to declare infrastructure as code.

--- a/radar/infrastructure_config/vmware.yaml
+++ b/radar/infrastructure_config/vmware.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: VM Ware
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: HOLD
 description: |
   VM Ware is a software to run and manage virtual machines. VM Ware has been for

--- a/radar/infrastructure_config/webpack.yaml
+++ b/radar/infrastructure_config/webpack.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Webpack
 logo: https://upload.wikimedia.org/wikipedia/commons/c/c1/Webpack.png
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   Webpack is a module bundler. Its main purpose is to bundle JavaScript files for usage in a browser, yet it is also capable of transforming, bundling, or packaging just about any resource or asset.

--- a/radar/infrastructure_config/yum.yaml
+++ b/radar/infrastructure_config/yum.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: YUM
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: TRIAL
 description: |
   Linux package management to find packages and resolve dependencies between RPM packages.

--- a/radar/languages_frameworks/cucumber.yaml
+++ b/radar/languages_frameworks/cucumber.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Cucumber
 logo: https://docs.cucumber.io/img/cucumber-logo.png
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   Cucumber is a software tool used by computer programmers for testing other software.

--- a/radar/languages_frameworks/enunciate.yaml
+++ b/radar/languages_frameworks/enunciate.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Enunciate
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: HOLD
 description: |
   Enunciate is a framework to create HTML documentation and client APIs for your

--- a/radar/languages_frameworks/java.yaml
+++ b/radar/languages_frameworks/java.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Java
 logo: https://upload.wikimedia.org/wikipedia/en/thumb/3/30/Java_programming_language_logo.svg/234px-Java_programming_language_logo.svg.png
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   Java is an object-oriented programming language that runs in a Java Runtime Environment (JRE).

--- a/radar/languages_frameworks/javafx.yaml
+++ b/radar/languages_frameworks/javafx.yaml
@@ -2,7 +2,7 @@ version: 1
 name: JavaFX
 logo: https://upload.wikimedia.org/wikipedia/en/c/cc/JavaFX_Logo.png
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: HOLD
 description: |
   JavaFX is a desktop application platform by Oracle. It is intended to replace

--- a/radar/languages_frameworks/javascript.yaml
+++ b/radar/languages_frameworks/javascript.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: JavaScript
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   JavaScript, often abbreviated as JS, is a high-level, interpreted programming language.

--- a/radar/languages_frameworks/jersey_v1.yaml
+++ b/radar/languages_frameworks/jersey_v1.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Jersey 1.x
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: HOLD
 description: |
   Jersey 1.x is the reference implementation for JAX-RS 1. It is a framework

--- a/radar/languages_frameworks/nativescript.yaml
+++ b/radar/languages_frameworks/nativescript.yaml
@@ -2,7 +2,7 @@ version: 1
 name: NativeScript
 logo: https://www.nativescript.org/images/default-source/logos/nativescript-logo.png?sfvrsn=2
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: TRIAL
 description: |
   Open source framework for building truly native mobile apps with Angular, Vue.js, TypeScript, or JavaScript.

--- a/radar/languages_frameworks/nodejs.yaml
+++ b/radar/languages_frameworks/nodejs.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Node.js
 logo: https://upload.wikimedia.org/wikipedia/commons/d/d9/Node.js_logo.svg
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: TRIAL
 description: |
   _Node.js_ is javascript on the server. It is asynchronous and event driven

--- a/radar/languages_frameworks/openapi.yaml
+++ b/radar/languages_frameworks/openapi.yaml
@@ -2,7 +2,7 @@ version: 1
 name: OpenAPI (Swagger)
 logo: https://upload.wikimedia.org/wikipedia/commons/a/ab/Swagger-logo.png
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   The OpenAPI specification is a formal description of a RESTful web service

--- a/radar/languages_frameworks/postman.yaml
+++ b/radar/languages_frameworks/postman.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Postman
 logo: https://www.getpostman.com/img/v2/logo-mark.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   Postman is an API testing and development tool. At the core are Postman Collections which

--- a/radar/languages_frameworks/reactnative.yaml
+++ b/radar/languages_frameworks/reactnative.yaml
@@ -2,7 +2,7 @@ version: 1
 name: React Native
 logo: https://facebook.github.io/react-native/img/header_logo.png
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ASSESS
 description: |
   React Native lets you build mobile apps using only JavaScript. It uses the same design as React, letting you compose a rich mobile UI from declarative components.

--- a/radar/languages_frameworks/scss.yaml
+++ b/radar/languages_frameworks/scss.yaml
@@ -2,7 +2,7 @@ version: 1
 name: SCSS
 logo: https://sass-lang.com/assets/img/logos/logo-b6e1ef6e.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ADOPT
 description: |
   Sass 3 introduces a new syntax known as SCSS which is fully compatible with the syntax of CSS, while still supporting the full power of Sass.

--- a/radar/languages_frameworks/spring_boot2.yaml
+++ b/radar/languages_frameworks/spring_boot2.yaml
@@ -2,9 +2,9 @@ version: 1
 name: Spring Boot 2
 logo: https://spring.io/img/homepage/icon-spring-boot.svg
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ASSESS
-  - version: "1.1.0"
+  - version: "2.0"
     ring: TRIAL
 description: |
   Spring Boot 2 is an opioninated Spring library to create Spring application quickly.

--- a/radar/languages_frameworks/spring_cloud_contract.yaml
+++ b/radar/languages_frameworks/spring_cloud_contract.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Spring Cloud Contract
 logo: https://spring.io/img/homepage/icon-spring-cloud.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ASSESS
 description: |
 #rationale: |

--- a/radar/languages_frameworks/spring_framework.yaml
+++ b/radar/languages_frameworks/spring_framework.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Spring Framework
 logo: https://spring.io/img/homepage/icon-spring-framework.svg
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: HOLD
 description: |
   Spring Framework is an application framework and IoC container for Java.

--- a/radar/techniques/12factor.yaml
+++ b/radar/techniques/12factor.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Twelve-factor app
 shortname: 12-factor app
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   [The twelve-factor app](https://12factor.net/) is a methodology for building maintanable SaaS applications.

--- a/radar/techniques/airbnb_javascript_style_guide.yaml
+++ b/radar/techniques/airbnb_javascript_style_guide.yaml
@@ -2,7 +2,7 @@ version: 1
 name: AirBnB JavaScript Style Guide
 shortname: AirBnB JS Guide
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: TRIAL
 description: |
   [A mostly reasonable approach to JavaScript.](https://github.com/airbnb/javascript)

--- a/radar/techniques/iam_saas.yaml
+++ b/radar/techniques/iam_saas.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: IAM SaaS
 blip:
-  - version: "1.1.0"
+  - version: "2.0"
     ring: ASSESS
 description: |
   A centralized, SaaS solution for Identity and Access Management (IAM) is necessary

--- a/radar/techniques/infrastructure_as_code.yaml
+++ b/radar/techniques/infrastructure_as_code.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Infrastructure as code
 shortname: Infra. as code
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   Infrastructure as code (IaC) is the process of managing and provisioning infrastructure

--- a/radar/techniques/pipelines_as_code.yaml
+++ b/radar/techniques/pipelines_as_code.yaml
@@ -1,7 +1,7 @@
 version: 1
 name: Pipelines as code
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   _Pipelines as code_ is defining the build and deployment pipeline through

--- a/radar/techniques/semver.yaml
+++ b/radar/techniques/semver.yaml
@@ -2,7 +2,7 @@ version: 1
 name: Semantic versioning
 shortname: Semantic version
 blip:
-  - version: "1.0.0"
+  - version: "1.0"
     ring: ADOPT
 description: |
   In short, [semantic versioning](https://semver.org) is a versioning scheme where the following rules govern how versions change:


### PR DESCRIPTION
* Rename all 1.1.0 blips to 2.0 to prepare for major version bump
* Best effort movement calculation also for local dev build