### PR TITLE
feat: added github as a new tech blip

### DIFF
--- a/radar/data_management/github.yaml
+++ b/radar/data_management/github.yaml
@@ -1,6 +1,6 @@
 name: Github
 blip:
-  - version: "1.0"
+  - date: 2019-05-22
     ring: ADOPT
 description: |
   GitHub brings teams together to work through problems, move ideas forward,

--- a/radar/data_management/github.yaml
+++ b/radar/data_management/github.yaml
@@ -1,0 +1,19 @@
+name: Github
+blip:
+  - version: "1.0"
+    ring: ADOPT
+description: |
+  GitHub brings teams together to work through problems, move ideas forward,
+  and learn from each other along the way. GitHub provides access control and several
+  collaboration features such as bug tracking, feature requests, task management,
+  and wikis for every project.
+
+  GitHub offers plans for enterprise, team, pro and free accounts which are commonly
+  used to host open-source software projects. As of January 2019, GitHub offers
+  unlimited private repositories to all plans, including free accounts.
+rationale: |
+  Using GitHub makes it easier to collaborate with colleagues and peers
+  and look back at previous versions of your work. We have many integrations to github
+  from other tools, e.g spinnaker, sonarcube, jenkins.
+related:
+  - infrastructure_config/git.yaml


### PR DESCRIPTION
We use github allot. Should be added to tech radar.