### PR TITLE
fix: Change GitHub quadrant and add related links

### DIFF
--- a/radar/infrastructure_config/bitbucket.yaml
+++ b/radar/infrastructure_config/bitbucket.yaml
@@ -20,3 +20,6 @@ rationale: |
   We have standardized on GIT and Jira, so this is the repository chosen for
   Retail Suite. With its nice integration to Jira it offers the functionality
   required for developers. The pricing is USD 2.0 per month per developer.
+related:
+  - infrastructure_config/git.yaml
+  - infrastructure_config/github.yaml

--- a/radar/infrastructure_config/git.yaml
+++ b/radar/infrastructure_config/git.yaml
@@ -12,3 +12,4 @@ rationale: |
   Git has proven to have all capabilities needed without being hard to learn or use which makes it the obvious choice.
 related:
   - infrastructure_config/bitbucket.yaml
+  - infrastructure_config/github.yaml

--- a/radar/infrastructure_config/github.yaml
+++ b/radar/infrastructure_config/github.yaml
@@ -1,4 +1,4 @@
-name: Github
+name: GitHub
 blip:
   - date: 2019-05-22
     ring: ADOPT
@@ -16,3 +16,6 @@ rationale: |
   Using GitHub makes it easier to collaborate with colleagues and peers
   and look back at previous versions of your work. We have many integrations to github
   from other tools, e.g Spinnaker, Sonarcube, Jenkins.
+related:
+  - infrastructure_config/git.yaml
+  - infrastructure_config/bitbucket.yaml


### PR DESCRIPTION
Move GitHub to the `Infrastructure & Config` quadrant and add links between Git, BitBucket and GitHub.