### PR TITLE
Don't run Sonar from forked PRs [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,10 @@ workflows:
           context: sonarcloud
           requires:
             - build
+          filters:
+            branches:
+              # Don't run Sonar on forked PRs
+              ignore: /^pull\/.*$/
       - dockerhub:
           context: dockerhub
           requires:


### PR DESCRIPTION
Pipeline update to skip SonarCloud analysis from forked PRs. We skip execution because for security reasons CircleCI doesn't recommend sharing build secrets with forks.