### PR TITLE
feat: Add license info to radar entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The following open source license names are valid for use in the radar blips.
 | EDL-1.0     | Eclipse Distribution License (EDL) Version 1.0                   |
 | LGPL-2.1    | GNU Lesser General Public License (LGPL) Version 2.1             |
 | LGPL-3.0    | GNU Lesser General Public License (LGPL) Version 3.0             |
-| GPL-CPE     | GNU General Public License (GPL) with the Classpath Exception    |
+| GPL-CE      | GNU General Public License (GPL) with the Classpath Exception    |
 | MIT         | The MIT License                                                  |
 | MPL-1.0     | Mozilla Public License (MPL) Version 1.0                         |
 | MPL-1.1     | Mozilla Public License (MPL) Version 1.1                         |

--- a/README.md
+++ b/README.md
@@ -112,12 +112,17 @@ rationale: |
   This entry can be multiple lines and supports Markdown.
 license: # Optional, but recommended to always include
   # Only if open source
-  opensource:
-    name: MIT # Valid enum open-source name (from enum)
+  open-source:
+    name: MIT # Required open-source license. Must match enum in schema.
     link: http://github.com/org/repo/LICENSE # Optional link to license
+    description: |
+      Optional description of the open source license. Do not use unless something must be explained,
+      for example with dual licenses. Supports markdown.
   # Only if commercial
-  commercial: |
-    Describe the commercial license using Markdown.
+  commercial:
+    company: Google # Required company name. Must match enum in schema.
+    description: |
+      Optional description of the commercial license that supports Markdown.
 related: # Optional list of related entries
   - qa/semver.yaml # Relative path of related entry from radar dir.
 tags: # Optional list of tags.
@@ -141,7 +146,7 @@ And to validate the YAML against its schema definition, use:
 $ npm run yaml:validate
 ```
 
-### Open Source License Listings
+### Supported Open-Source Licenses
 
 The following open source license names are valid for use in the radar blips.
 
@@ -171,6 +176,20 @@ If you find a library with a license that isn't in this list it must be analyzed
 The list only contains license types analyzed for compliance with Extenda Retail products.
 
 For projects with multiple licenses, select the most permissible one and make sure it is compatible with Extenda Retail's licensing.
+
+### Supported Commercial Licenses
+
+The following companies are valid for use with commercial licenses.
+
+  * Amazon
+  * Google
+  * Jaspersoft
+  * Microsoft
+  * Oracle
+  * Qlik
+  * Tanuki Software
+
+If you add a radar entry that requires a license from some other company, this means the company must be added to the tech-radar model and schemas.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The following open source license names are valid for use in the radar blips.
 | MIT         | The MIT License                                                  |
 | MPL-1.0     | Mozilla Public License (MPL) Version 1.0                         |
 | MPL-1.1     | Mozilla Public License (MPL) Version 1.1                         |
-| MPL-1.1     | Mozilla Public License (MPL) Version 2.0                         |
+| MPL-2.0     | Mozilla Public License (MPL) Version 2.0                         |
 | Public      | Public Domain                                                    |
 
 If you find a library with a license that isn't in this list it must be analyzed in detail.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ description: |
 rationale: |
   A required rationale to explain why the technology is assessed in its current ring.
   This entry can be multiple lines and supports Markdown.
+license: # Optional, but recommended to always include
+  # Only if open source
+  opensource:
+    name: MIT # Valid enum open-source name (from enum)
+    link: http://github.com/org/repo/LICENSE # Optional link to license
+  # Only if commercial
+  commercial: |
+    Describe the commercial license using Markdown.
 related: # Optional list of related entries
   - qa/semver.yaml # Relative path of related entry from radar dir.
 tags: # Optional list of tags.
@@ -132,6 +140,37 @@ And to validate the YAML against its schema definition, use:
 ```bash
 $ npm run yaml:validate
 ```
+
+### Open Source License Listings
+
+The following open source license names are valid for use in the radar blips.
+
+| Name        | Description                                                      |
+| ----------- | ---------------------------------------------------------------- |
+| Apache-1.1  | Apache Software License Version 1.1                              |
+| Apache-2.0  | Apache Software License Version 2.0                              |
+| BSD-2       | Simplified BSD License (BSD 2-Clause License)                    |
+| BSD-3       | New BSD License (BSD 3-Clause License)                           |
+| BSD-4       | Original BSD License (BSD 4-Clause License)                      |
+| BSD-style   | BSD-style license, see project license for details               |
+| CC0         | Creative Commons Public Domain                                   |
+| CDDL-1.0    | Common Development and Distribution License (CDDL) Version 1.0   |
+| CDDL-1.1    | Common Development and Distribution License (CDDL) Version 1.1   |
+| EPL-1.0     | Eclipse Public License (EPL) Version 1.0                         |
+| EDL-1.0     | Eclipse Distribution License (EDL) Version 1.0                   |
+| LGPL-2.1    | GNU Lesser General Public License (LGPL) Version 2.1             |
+| LGPL-3.0    | GNU Lesser General Public License (LGPL) Version 3.0             |
+| GPL-CPE     | GNU General Public License (GPL) with the Classpath Exception    |
+| MIT         | The MIT License                                                  |
+| MPL-1.0     | Mozilla Public License (MPL) Version 1.0                         |
+| MPL-1.1     | Mozilla Public License (MPL) Version 1.1                         |
+| MPL-1.1     | Mozilla Public License (MPL) Version 2.0                         |
+| Public      | Public Domain                                                    |
+
+If you find a library with a license that isn't in this list it must be analyzed in detail.
+The list only contains license types analyzed for compliance with Extenda Retail products.
+
+For projects with multiple licenses, select the most permissible one and make sure it is compatible with Extenda Retail's licensing.
 
 ### Docker
 

--- a/radar/data_management/mysql.yaml
+++ b/radar/data_management/mysql.yaml
@@ -6,15 +6,16 @@ description: |
   MySQL is a relational database by Oracle.
 rationale: |
   MySQL is in use at Extenda Retail, for example to store reference data.
-  Commercial use of MySQL requires a license agreement with Oracle and places
-  restrictions on how MySQL is installed and used and which driver packages
-  we can use to connect from our software.
-
-  Future solutions should look for alternatives to MySQL.
+  Future solutions should look for alternatives to MySQL due to footprint and licensing.
 
     * Is a relational database the best fit?
     * If cloud, look for cloud native solutions - don't spin up MySQL
     * Thin clients can't depend on a local MySQL database
+license:
+  commercial: |
+    Commercial use of MySQL requires a license agreement with Oracle and places
+    restrictions on how MySQL is installed and used and which driver packages
+    we can use to connect from our software.
 tags:
   - java
   - sql

--- a/radar/data_management/mysql.yaml
+++ b/radar/data_management/mysql.yaml
@@ -12,10 +12,12 @@ rationale: |
     * If cloud, look for cloud native solutions - don't spin up MySQL
     * Thin clients can't depend on a local MySQL database
 license:
-  commercial: |
-    Commercial use of MySQL requires a license agreement with Oracle and places
-    restrictions on how MySQL is installed and used and which driver packages
-    we can use to connect from our software.
+  commercial:
+    company: Oracle
+    description: |
+      Commercial use of MySQL requires a license agreement with Oracle and places
+      restrictions on how MySQL is installed and used and which driver packages
+      we can use to connect from our software.
 tags:
   - java
   - sql

--- a/radar/dev/java.yaml
+++ b/radar/dev/java.yaml
@@ -25,7 +25,7 @@ rationale: |
   work on supported Java versions and don't lag behind on Java 8 after EOL.
 license:
   open-source:
-    name: GPL-CPE
+    name: GPL-CE
     link: https://openjdk.java.net/legal/gplv2+ce.html
   commercial: |
     Oracle JRE requires a commercial license from Oracle to be used on POS workstations and servers.

--- a/radar/dev/java.yaml
+++ b/radar/dev/java.yaml
@@ -27,10 +27,11 @@ license:
   open-source:
     name: GPL-CE
     link: https://openjdk.java.net/legal/gplv2+ce.html
-  commercial: |
-    Oracle JRE requires a commercial license from Oracle to be used on POS workstations and servers.
-    This license includes SLAs from Oracle.
-    OpenJDK does not require any license and is released on GPL with a classpath exception, which means we can use it
-    to run our commercial applications.
+  commercial:
+    company: Oracle
+    description: |
+      Oracle JRE requires a commercial license from Oracle to be used on POS workstations and servers.
+      This license includes SLAs from Oracle. OpenJDK does not require any license and is released on
+      GPL with a classpath exception, which means we can use it to run our commercial applications.
 tags:
   - java

--- a/radar/dev/java.yaml
+++ b/radar/dev/java.yaml
@@ -23,5 +23,14 @@ rationale: |
   For existing systems, it is important to start to upgrade to the next LTS
   release after Java 8 (at this time Java 11). We must make sure our products
   work on supported Java versions and don't lag behind on Java 8 after EOL.
+license:
+  open-source:
+    name: GPL-CPE
+    link: https://openjdk.java.net/legal/gplv2+ce.html
+  commercial: |
+    Oracle JRE requires a commercial license from Oracle to be used on POS workstations and servers.
+    This license includes SLAs from Oracle.
+    OpenJDK does not require any license and is released on GPL with a classpath exception, which means we can use it
+    to run our commercial applications.
 tags:
   - java

--- a/radar/dev/react.yaml
+++ b/radar/dev/react.yaml
@@ -12,6 +12,10 @@ rationale: |
   React allows for lightweight component based UI's, like POS clients. React is currently being
   used in the new POS client, sharing code between React Native for mobile clients and Electron
   for desktop.
+license:
+  open-source:
+    name: MIT
+    link: https://github.com/facebook/react/blob/master/LICENSE
 related:
   - dev/angular.yaml
   - dev/typescript.yaml

--- a/radar/dev/react.yaml
+++ b/radar/dev/react.yaml
@@ -15,7 +15,7 @@ rationale: |
 license:
   open-source:
     name: MIT
-    link: https://github.com/facebook/react/blob/master/LICENSE
+    link: https://raw.githubusercontent.com/facebook/react/master/LICENSE
 related:
   - dev/angular.yaml
   - dev/typescript.yaml

--- a/radar/dev/reactnative.yaml
+++ b/radar/dev/reactnative.yaml
@@ -9,6 +9,10 @@ description: |
 rationale: |
   As an alternative to NativeSceript, React Native takes a more explicit approach to
   building apps on iOS and Android.
+license:
+  open-source:
+    name: MIT
+    link: https://raw.githubusercontent.com/facebook/react-native/master/LICENSE
 tags:
   - android
   - ios

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -194,9 +194,6 @@ ul.tags {
   list-style: none;
 }
 
-ul.tags li {
-}
-
 .entry-tag {
   display: inline-block;
   box-sizing: border-box;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -163,6 +163,11 @@ ul.history {
   color: white;
 }
 
+.badge.license {
+  background: #fefefe;
+  border: 1px solid #cfd8dc;
+}
+
 ul.adopt, ul.assess, ul.trial, ul.hold {
   border-left-width: 3px;
   border-left-style: solid;

--- a/src/js/builder/reader.js
+++ b/src/js/builder/reader.js
@@ -80,6 +80,7 @@ const createLicenseTags = (entry) => {
   const { license } = entry;
   if (license && license.commercial) {
     tags.push('commercial');
+    tags.push(license.commercial.company.toLowerCase());
   }
 
   if (license && license['open-source']) {

--- a/src/js/builder/reader.js
+++ b/src/js/builder/reader.js
@@ -75,6 +75,35 @@ const createBlip = (entry) => {
   return blip;
 };
 
+const createLicenseTags = (entry) => {
+  const tags = [];
+  const { license } = entry;
+  if (license && license.commercial) {
+    tags.push('commercial');
+  }
+
+  if (license && license['open-source']) {
+    const { 'open-source': { name } } = license;
+    tags.push('open-source');
+    tags.push(name.toLowerCase());
+
+    const reg = /^(.*)-[0-9\\.]+$/;
+    if (reg.test(name)) {
+      // Tag with the base license, excluding version/style
+      tags.push(name.match(reg)[1].toLowerCase());
+    }
+  }
+
+  return tags;
+};
+
+const createTags = (entry) => {
+  const tags = entry.tags ? entry.tags.map(t => t.toLowerCase()) : [];
+  tags.push(...createLicenseTags(entry));
+  tags.sort((a, b) => a.localeCompare(b));
+  return tags;
+};
+
 const collectEntries = (radarDir, callback) => {
   const klawOpts = {
     nodir: true,
@@ -90,7 +119,7 @@ const collectEntries = (radarDir, callback) => {
     entry.filename = htmlFile(f.path);
     entry.blip = createBlip(entry);
     entry.related = buildRelatedLinks(entry);
-    entry.tags = entry.tags ? entry.tags.map(t => t.toLowerCase()) : [];
+    entry.tags = createTags(entry);
     callback(entry);
   });
 };

--- a/src/js/builder/reader.js
+++ b/src/js/builder/reader.js
@@ -120,6 +120,10 @@ const collectEntries = (radarDir, callback) => {
     entry.blip = createBlip(entry);
     entry.related = buildRelatedLinks(entry);
     entry.tags = createTags(entry);
+    if (entry.license && entry.license['open-source']) {
+      entry.license.openSource = entry.license['open-source'];
+      delete entry.license['open-source'];
+    }
     callback(entry);
   });
 };

--- a/src/js/components/Entry.jsx
+++ b/src/js/components/Entry.jsx
@@ -6,8 +6,10 @@ import Related from './entry/Related';
 import History from './entry/History';
 import Badge from './entry/Badge';
 import Tags from './entry/Tags';
+import License from './entry/License';
 import Navigation from './Navigation';
 import NotFound from './NotFound';
+import LicenseBadges from './entry/LicenseBadges';
 
 const Entry = (props) => {
   const { match } = props;
@@ -38,6 +40,7 @@ const Entry = (props) => {
             {(entry.blip.active === false) && (
               <Badge className="inactive" icon="warning" text="Inactive" />
             )}
+            <LicenseBadges license={entry.license} />
           </div>
           <div className="twelve columns">
             <Markdown source={entry.description} />
@@ -47,6 +50,7 @@ const Entry = (props) => {
                 <Markdown source={entry.rationale} />
               </React.Fragment>
             )}
+            <License license={entry.license} />
             <Related related={entry.related} />
             <History history={entry.blip.history} />
           </div>

--- a/src/js/components/entry/Badge.jsx
+++ b/src/js/components/entry/Badge.jsx
@@ -3,12 +3,27 @@ import PropTypes from 'prop-types';
 import Icon from '../Icon';
 
 const Badge = (props) => {
-  const { className, icon, text } = props;
+  const {
+    className,
+    icon,
+    text,
+    link,
+  } = props;
+
+  let content;
+
+  if (link) {
+    content = (
+      <a href={link}>{text}</a>
+    );
+  } else {
+    content = text;
+  }
 
   return (
     <span className={`badge ${className}`}>
       <Icon name={icon} spaceBefore={false} />
-      {text}
+      {content}
     </span>
   );
 };
@@ -17,10 +32,12 @@ Badge.propTypes = {
   className: PropTypes.string,
   icon: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  link: PropTypes.string,
 };
 
 Badge.defaultProps = {
   className: '',
+  link: null,
 };
 
 export default Badge;

--- a/src/js/components/entry/License.jsx
+++ b/src/js/components/entry/License.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Markdown from 'react-markdown';
+import Icon from '../Icon';
+
+const OS_LICENSES = {
+  'Apache-1.1': 'Apache Software License Version 1.1',
+  'Apache-2.0': 'Apache Software License Version 2.0',
+  'BSD-2': 'Simplified BSD License (BSD 2-Clause License)',
+  'BSD-3': 'New BSD License (BSD 3-Clause License)',
+  'BSD-4': 'Original BSD License (BSD 4-Clause License)',
+  'BSD-style': 'BSD-style license, see project license for details',
+  CC0: 'Creative Commons Public Domain',
+  'CDDL-1.0': 'Common Development and Distribution License (CDDL) Version 1.0',
+  'CCDL-1.1': 'Common Development and Distribution License (CDDL) Version 1.1',
+  'EPL-1.0': 'Eclipse Public License (EPL) Version 1.0',
+  'EDL-1.0': 'Eclipse Distribution License (EDL) Version 1.0',
+  'LGPL-2.1': 'GNU Lesser General Public License (LGPL) Version 2.1',
+  'LGPL-3.0': 'GNU Lesser General Public License (LGPL) Version 3.0',
+  'GPL-CPE': 'GNU General Public License (GPL) with the Classpath Exception',
+  MIT: 'The MIT License',
+  'MPL-1.0': 'Mozilla Public License (MPL) Version 1.0',
+  'MPL-1.1': 'Mozilla Public License (MPL) Version 1.1',
+  'MPL-2.0': 'Mozilla Public License (MPL) Version 2.0',
+  Public: 'Public Domain',
+};
+
+const License = (props) => {
+  const { license: { openSource, commercial } } = props;
+
+  if (openSource == null && commercial == null) {
+    return null;
+  }
+
+  return (
+    <React.Fragment>
+      <h2>
+        License
+      </h2>
+      {openSource && (
+        <div>
+          <strong>
+            <Icon name="check" />
+            Available for use under an open-source license.
+          </strong>
+          <p>
+            {openSource.link
+              ? <a href={openSource.link}>{OS_LICENSES[openSource.name]}</a>
+              : OS_LICENSES[openSource.name]}
+          </p>
+        </div>
+      )}
+      {commercial && (
+        <div>
+          <strong>
+            <Icon name="exclamation-triangle" />
+            Available for use with a commercial agreement.
+          </strong>
+          <Markdown source={commercial} />
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+License.propTypes = {
+  license: PropTypes.shape({
+    openSource: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      link: PropTypes.string,
+    }),
+    commercial: PropTypes.string,
+  }),
+};
+
+License.defaultProps = {
+  license: {
+    openSource: null,
+    commercial: null,
+  },
+};
+
+export default License;

--- a/src/js/components/entry/License.jsx
+++ b/src/js/components/entry/License.jsx
@@ -25,6 +25,13 @@ const OS_LICENSES = {
   Public: 'Public Domain',
 };
 
+const COMMERCIAL_DEFAULT_TEXT = {
+  Google: 'Use of this software requires a license for Google Cloud Platform.',
+};
+
+const commercialDescription = commercial => commercial.description
+  || COMMERCIAL_DEFAULT_TEXT[commercial.company];
+
 const License = (props) => {
   const { license: { openSource, commercial } } = props;
 
@@ -48,15 +55,23 @@ const License = (props) => {
               ? <a href={openSource.link}>{OS_LICENSES[openSource.name]}</a>
               : OS_LICENSES[openSource.name]}
           </p>
+          {openSource.description && (
+            <Markdown source={openSource.description} />
+          )}
         </div>
       )}
       {commercial && (
         <div>
           <strong>
             <Icon name="exclamation-triangle" />
-            Available for use with a commercial agreement.
+            Available for use with a commercial agreement from
+            {' '}
+            {commercial.company}
+            .
           </strong>
-          <Markdown source={commercial} />
+          {commercialDescription(commercial) && (
+            <Markdown source={commercialDescription(commercial)} />
+          )}
         </div>
       )}
     </React.Fragment>
@@ -68,8 +83,12 @@ License.propTypes = {
     openSource: PropTypes.shape({
       name: PropTypes.string.isRequired,
       link: PropTypes.string,
+      description: PropTypes.string,
     }),
-    commercial: PropTypes.string,
+    commercial: PropTypes.shape({
+      company: PropTypes.string.isRequired,
+      description: PropTypes.string,
+    }),
   }),
 };
 

--- a/src/js/components/entry/License.jsx
+++ b/src/js/components/entry/License.jsx
@@ -17,7 +17,7 @@ const OS_LICENSES = {
   'EDL-1.0': 'Eclipse Distribution License (EDL) Version 1.0',
   'LGPL-2.1': 'GNU Lesser General Public License (LGPL) Version 2.1',
   'LGPL-3.0': 'GNU Lesser General Public License (LGPL) Version 3.0',
-  'GPL-CPE': 'GNU General Public License (GPL) with the Classpath Exception',
+  'GPL-CE': 'GNU General Public License (GPL) with the Classpath Exception',
   MIT: 'The MIT License',
   'MPL-1.0': 'Mozilla Public License (MPL) Version 1.0',
   'MPL-1.1': 'Mozilla Public License (MPL) Version 1.1',

--- a/src/js/components/entry/LicenseBadges.jsx
+++ b/src/js/components/entry/LicenseBadges.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import License from './License';
+import Badge from './Badge';
+
+const LicenseBadges = (props) => {
+  const { license: { openSource, commercial } } = props;
+
+  return (
+    <React.Fragment>
+      {openSource && (
+        <Badge icon="balance-scale" className="license" text={openSource.name} link={openSource.link} />
+      )}
+      {commercial && (
+        <Badge icon="balance-scale" className="license" text="Commercial" />
+      )}
+    </React.Fragment>
+  );
+};
+
+LicenseBadges.propTypes = {
+  ...License.propTypes,
+};
+
+LicenseBadges.defaultProps = {
+  ...License.defaultProps,
+};
+
+export default LicenseBadges;

--- a/src/js/modules/radarService.js
+++ b/src/js/modules/radarService.js
@@ -29,11 +29,12 @@ class RadarService {
   };
 
   listTags = () => {
-    const tags = [];
+    const tags = new Set();
     this.model.entries.forEach((entry) => {
-      tags.push(...entry.tags);
+      entry.tags.every(tag => tags.add(tag));
     });
-    return [...new Set(tags)];
+
+    return [...tags].sort((a, b) => a.localeCompare(b));
   };
 
   listEntries = (quadrant, ring, active = true) => {

--- a/src/radar_entry.schema.yaml
+++ b/src/radar_entry.schema.yaml
@@ -63,8 +63,25 @@ mapping:
           "link":
             type: str
             pattern: ^http(s)?://.*$
+          "description":
+            type: str
       "commercial":
-        type: str
+        type: map
+        mapping:
+          "company":
+            type: str
+            required: true
+            enum: [
+              Amazon,
+              Google,
+              Jaspersoft,
+              Microsoft,
+              Oracle,
+              Qlik,
+              "Tanuki Software",
+            ]
+          "description":
+            type: str
   "related":
     type: seq
     sequence:

--- a/src/radar_entry.schema.yaml
+++ b/src/radar_entry.schema.yaml
@@ -30,6 +30,41 @@ mapping:
   "rationale":
     type: str
     required: true
+  "license":
+    type: map
+    mapping:
+      "open-source":
+        type: map
+        mapping:
+          "name":
+            type: str
+            required: true
+            enum: [
+              Apache-1.1,
+              Apache-2.0,
+              BSD-2,
+              BSD-3,
+              BSD-4,
+              BSD-style,
+              CC0,
+              CDDL-1.0,
+              CDDL-1.1,
+              LGPL-2.1,
+              LGPL-3.0,
+              EPL-1.0,
+              EDL-1.0,
+              GPL-CPE,
+              MIT,
+              MPL-1.0,
+              MPL-1.1,
+              MPL-2.0,
+              Public,
+            ]
+          "link":
+            type: str
+            pattern: ^http(s)?://.*$
+      "commercial":
+        type: str
   "related":
     type: seq
     sequence:

--- a/src/radar_entry.schema.yaml
+++ b/src/radar_entry.schema.yaml
@@ -53,7 +53,7 @@ mapping:
               LGPL-3.0,
               EPL-1.0,
               EDL-1.0,
-              GPL-CPE,
+              GPL-CE,
               MIT,
               MPL-1.0,
               MPL-1.1,

--- a/test/Badge.test.jsx
+++ b/test/Badge.test.jsx
@@ -12,4 +12,9 @@ describe('<Badge />', () => {
     const component = shallow(<Badge icon="test" text="test" className="my-test" />);
     expect(component).toMatchSnapshot();
   });
+
+  test('It renders badge with link', () => {
+    const icon = shallow(<Badge icon="test" text="test" link="http://test.com" />);
+    expect(icon.find('a')).toHaveLength(1);
+  });
 });

--- a/test/License.test.jsx
+++ b/test/License.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import License from '../src/js/components/entry/License';
+
+describe('<License />', () => {
+  test('It renders nothing for missing license', () => {
+    const component = shallow(<License />);
+    expect(component).toMatchSnapshot();
+  });
+
+  test('It renders open-source license', () => {
+    const component = shallow(<License license={{ openSource: { name: 'MIT' } }} />);
+    expect(component).toMatchSnapshot();
+    expect(component.html()).toMatch('The MIT License');
+  });
+
+  test('It renders open-source license with link', () => {
+    const component = shallow(<License license={{ openSource: { name: 'MIT', link: 'https://license.com' } }} />);
+    expect(component).toMatchSnapshot();
+    expect(component.find('a')).toHaveLength(1);
+  });
+
+  test('It renders commercial license', () => {
+    const component = shallow(<License license={{ commercial: 'License text.' }} />);
+    expect(component).toMatchSnapshot();
+    expect(component.html()).toMatch('License text');
+  });
+
+  test('It renders dual license', () => {
+    const component = shallow(
+      <License
+        license={{
+          commercial: 'License text.',
+          openSource: { name: 'MIT' },
+        }}
+      />,
+    );
+    expect(component).toMatchSnapshot();
+    expect(component.html()).toMatch('The MIT License');
+    expect(component.html()).toMatch('License text');
+  });
+});

--- a/test/License.test.jsx
+++ b/test/License.test.jsx
@@ -14,6 +14,13 @@ describe('<License />', () => {
     expect(component.html()).toMatch('The MIT License');
   });
 
+  test('It renders open-source license with description', () => {
+    const component = shallow(<License license={{ openSource: { name: 'MIT', description: 'OSS Desc' } }} />);
+    expect(component).toMatchSnapshot();
+    expect(component.html()).toMatch('The MIT License');
+    expect(component.html()).toMatch('OSS Desc');
+  });
+
   test('It renders open-source license with link', () => {
     const component = shallow(<License license={{ openSource: { name: 'MIT', link: 'https://license.com' } }} />);
     expect(component).toMatchSnapshot();
@@ -21,7 +28,13 @@ describe('<License />', () => {
   });
 
   test('It renders commercial license', () => {
-    const component = shallow(<License license={{ commercial: 'License text.' }} />);
+    const component = shallow(<License license={{ commercial: { company: 'Oracle' } }} />);
+    expect(component).toMatchSnapshot();
+    expect(component.html()).toMatch('Oracle');
+  });
+
+  test('It renders commercial license with description', () => {
+    const component = shallow(<License license={{ commercial: { company: 'Oracle', description: 'License text.' } }} />);
     expect(component).toMatchSnapshot();
     expect(component.html()).toMatch('License text');
   });
@@ -30,13 +43,13 @@ describe('<License />', () => {
     const component = shallow(
       <License
         license={{
-          commercial: 'License text.',
+          commercial: { company: 'Oracle' },
           openSource: { name: 'MIT' },
         }}
       />,
     );
     expect(component).toMatchSnapshot();
     expect(component.html()).toMatch('The MIT License');
-    expect(component.html()).toMatch('License text');
+    expect(component.html()).toMatch('Oracle');
   });
 });

--- a/test/LicenseBadges.test.jsx
+++ b/test/LicenseBadges.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import LicenseBadges from '../src/js/components/entry/LicenseBadges';
+import Badge from '../src/js/components/entry/Badge';
+
+describe('<LicenseBadges />', () => {
+  test('It renders no badges for missing license', () => {
+    const component = shallow(<LicenseBadges />);
+    expect(component).toMatchSnapshot();
+    expect(component.find(Badge)).toHaveLength(0);
+  });
+
+  test('It renders open-source badge', () => {
+    const component = shallow(
+      <LicenseBadges
+        license={{
+          openSource: {
+            name: 'MIT',
+            link: 'https://license.com',
+          },
+        }}
+      />,
+    );
+
+    expect(component).toMatchSnapshot();
+    expect(component.find(Badge)).toHaveLength(1);
+  });
+
+  test('It renders commercial badge', () => {
+    const component = shallow(
+      <LicenseBadges
+        license={{
+          commercial: 'The commercial agreement.',
+        }}
+      />,
+    );
+
+    expect(component).toMatchSnapshot();
+    expect(component.find(Badge)).toHaveLength(1);
+  });
+
+  test('It renders dual license', () => {
+    const component = shallow(
+      <LicenseBadges
+        license={{
+          commercial: 'The commercial agreement.',
+          openSource: {
+            name: 'MIT',
+            link: 'https://license.com',
+          },
+        }}
+      />,
+    );
+
+    expect(component.find(Badge)).toHaveLength(2);
+  });
+});

--- a/test/LicenseBadges.test.jsx
+++ b/test/LicenseBadges.test.jsx
@@ -30,7 +30,9 @@ describe('<LicenseBadges />', () => {
     const component = shallow(
       <LicenseBadges
         license={{
-          commercial: 'The commercial agreement.',
+          commercial: {
+            company: 'Oracle',
+          },
         }}
       />,
     );
@@ -43,7 +45,9 @@ describe('<LicenseBadges />', () => {
     const component = shallow(
       <LicenseBadges
         license={{
-          commercial: 'The commercial agreement.',
+          commercial: {
+            company: 'Oracle',
+          },
           openSource: {
             name: 'MIT',
             link: 'https://license.com',

--- a/test/__snapshots__/Entry.test.jsx.snap
+++ b/test/__snapshots__/Entry.test.jsx.snap
@@ -47,12 +47,22 @@ exports[`<Entry /> It renders entry with history 1`] = `
         <Badge
           className="Hold"
           icon="map-marker"
+          link={null}
           text="Hold"
         />
         <Badge
           className=""
           icon="clock-o"
+          link={null}
           text="Jan 1, 2004"
+        />
+        <LicenseBadges
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
       </div>
       <div
@@ -82,6 +92,14 @@ exports[`<Entry /> It renders entry with history 1`] = `
           source="Rationale"
           sourcePos={false}
           transformLinkUri={[Function]}
+        />
+        <License
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
         <Related
           related={Array []}
@@ -157,12 +175,22 @@ exports[`<Entry /> It renders entry with related links 1`] = `
         <Badge
           className="Adopt"
           icon="map-marker"
+          link={null}
           text="Adopt"
         />
         <Badge
           className=""
           icon="clock-o"
+          link={null}
           text="Mar 20, 2018"
+        />
+        <LicenseBadges
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
       </div>
       <div
@@ -192,6 +220,14 @@ exports[`<Entry /> It renders entry with related links 1`] = `
           source="Rationale"
           sourcePos={false}
           transformLinkUri={[Function]}
+        />
+        <License
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
         <Related
           related={
@@ -264,17 +300,28 @@ exports[`<Entry /> It renders inactive badge 1`] = `
         <Badge
           className="Hold"
           icon="map-marker"
+          link={null}
           text="Hold"
         />
         <Badge
           className=""
           icon="clock-o"
+          link={null}
           text="Jan 1, 1970"
         />
         <Badge
           className="inactive"
           icon="warning"
+          link={null}
           text="Inactive"
+        />
+        <LicenseBadges
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
       </div>
       <div
@@ -304,6 +351,14 @@ exports[`<Entry /> It renders inactive badge 1`] = `
           source="Rationale"
           sourcePos={false}
           transformLinkUri={[Function]}
+        />
+        <License
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
         <Related
           related={Array []}
@@ -380,12 +435,22 @@ exports[`<Entry /> It renders logotype if present 1`] = `
         <Badge
           className="Hold"
           icon="map-marker"
+          link={null}
           text="Hold"
         />
         <Badge
           className=""
           icon="clock-o"
+          link={null}
           text="Jan 1, 2004"
+        />
+        <LicenseBadges
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
       </div>
       <div
@@ -415,6 +480,14 @@ exports[`<Entry /> It renders logotype if present 1`] = `
           source="Rationale"
           sourcePos={false}
           transformLinkUri={[Function]}
+        />
+        <License
+          license={
+            Object {
+              "commercial": null,
+              "openSource": null,
+            }
+          }
         />
         <Related
           related={Array []}

--- a/test/__snapshots__/License.test.jsx.snap
+++ b/test/__snapshots__/License.test.jsx.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<License /> It renders commercial license 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="exclamation-triangle"
+        spaceBefore={true}
+      />
+      Available for use with a commercial agreement.
+    </strong>
+    <ReactMarkdown
+      astPlugins={Array []}
+      escapeHtml={true}
+      plugins={Array []}
+      rawSourcePos={false}
+      renderers={Object {}}
+      skipHtml={false}
+      source="License text."
+      sourcePos={false}
+      transformLinkUri={[Function]}
+    />
+  </div>
+</Fragment>
+`;
+
+exports[`<License /> It renders dual license 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="check"
+        spaceBefore={true}
+      />
+      Available for use under an open-source license.
+    </strong>
+    <p>
+      The MIT License
+    </p>
+  </div>
+  <div>
+    <strong>
+      <Icon
+        name="exclamation-triangle"
+        spaceBefore={true}
+      />
+      Available for use with a commercial agreement.
+    </strong>
+    <ReactMarkdown
+      astPlugins={Array []}
+      escapeHtml={true}
+      plugins={Array []}
+      rawSourcePos={false}
+      renderers={Object {}}
+      skipHtml={false}
+      source="License text."
+      sourcePos={false}
+      transformLinkUri={[Function]}
+    />
+  </div>
+</Fragment>
+`;
+
+exports[`<License /> It renders nothing for missing license 1`] = `""`;
+
+exports[`<License /> It renders open-source license 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="check"
+        spaceBefore={true}
+      />
+      Available for use under an open-source license.
+    </strong>
+    <p>
+      The MIT License
+    </p>
+  </div>
+</Fragment>
+`;
+
+exports[`<License /> It renders open-source license with link 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="check"
+        spaceBefore={true}
+      />
+      Available for use under an open-source license.
+    </strong>
+    <p>
+      <a
+        href="https://license.com"
+      >
+        The MIT License
+      </a>
+    </p>
+  </div>
+</Fragment>
+`;

--- a/test/__snapshots__/License.test.jsx.snap
+++ b/test/__snapshots__/License.test.jsx.snap
@@ -11,7 +11,30 @@ exports[`<License /> It renders commercial license 1`] = `
         name="exclamation-triangle"
         spaceBefore={true}
       />
-      Available for use with a commercial agreement.
+      Available for use with a commercial agreement from
+       
+      Oracle
+      .
+    </strong>
+  </div>
+</Fragment>
+`;
+
+exports[`<License /> It renders commercial license with description 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="exclamation-triangle"
+        spaceBefore={true}
+      />
+      Available for use with a commercial agreement from
+       
+      Oracle
+      .
     </strong>
     <ReactMarkdown
       astPlugins={Array []}
@@ -51,19 +74,11 @@ exports[`<License /> It renders dual license 1`] = `
         name="exclamation-triangle"
         spaceBefore={true}
       />
-      Available for use with a commercial agreement.
+      Available for use with a commercial agreement from
+       
+      Oracle
+      .
     </strong>
-    <ReactMarkdown
-      astPlugins={Array []}
-      escapeHtml={true}
-      plugins={Array []}
-      rawSourcePos={false}
-      renderers={Object {}}
-      skipHtml={false}
-      source="License text."
-      sourcePos={false}
-      transformLinkUri={[Function]}
-    />
   </div>
 </Fragment>
 `;
@@ -86,6 +101,37 @@ exports[`<License /> It renders open-source license 1`] = `
     <p>
       The MIT License
     </p>
+  </div>
+</Fragment>
+`;
+
+exports[`<License /> It renders open-source license with description 1`] = `
+<Fragment>
+  <h2>
+    License
+  </h2>
+  <div>
+    <strong>
+      <Icon
+        name="check"
+        spaceBefore={true}
+      />
+      Available for use under an open-source license.
+    </strong>
+    <p>
+      The MIT License
+    </p>
+    <ReactMarkdown
+      astPlugins={Array []}
+      escapeHtml={true}
+      plugins={Array []}
+      rawSourcePos={false}
+      renderers={Object {}}
+      skipHtml={false}
+      source="OSS Desc"
+      sourcePos={false}
+      transformLinkUri={[Function]}
+    />
   </div>
 </Fragment>
 `;

--- a/test/__snapshots__/LicenseBadges.test.jsx.snap
+++ b/test/__snapshots__/LicenseBadges.test.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LicenseBadges /> It renders commercial badge 1`] = `
+<Fragment>
+  <Badge
+    className="license"
+    icon="balance-scale"
+    link={null}
+    text="Commercial"
+  />
+</Fragment>
+`;
+
+exports[`<LicenseBadges /> It renders no badges for missing license 1`] = `<Fragment />`;
+
+exports[`<LicenseBadges /> It renders open-source badge 1`] = `
+<Fragment>
+  <Badge
+    className="license"
+    icon="balance-scale"
+    link="https://license.com"
+    text="MIT"
+  />
+</Fragment>
+`;

--- a/test/radar/valid/dev/java.yaml
+++ b/test/radar/valid/dev/java.yaml
@@ -8,7 +8,7 @@ rationale: |
   Rationale
 license:
   open-source:
-    name: GPL-CPE
+    name: GPL-CE
     link: https://openjdk.java.net/legal/gplv2+ce.html
   commercial: |
     Oracle JRE requires a commercial license to run on POS workstations and servers.

--- a/test/radar/valid/dev/java.yaml
+++ b/test/radar/valid/dev/java.yaml
@@ -10,9 +10,11 @@ license:
   open-source:
     name: GPL-CE
     link: https://openjdk.java.net/legal/gplv2+ce.html
-  commercial: |
-    Oracle JRE requires a commercial license to run on POS workstations and servers.
-    OpenJDK does not require this.
+  commercial:
+    company: Oracle
+    description: |
+      Oracle JRE requires a commercial license to run on POS workstations and servers.
+      OpenJDK does not require this.
 related:
   - dev/php.yaml
   - dev/lisp.yaml

--- a/test/radar/valid/dev/java.yaml
+++ b/test/radar/valid/dev/java.yaml
@@ -6,6 +6,13 @@ description: |
   Description
 rationale: |
   Rationale
+license:
+  open-source:
+    name: GPL-CPE
+    link: https://openjdk.java.net/legal/gplv2+ce.html
+  commercial: |
+    Oracle JRE requires a commercial license to run on POS workstations and servers.
+    OpenJDK does not require this.
 related:
   - dev/php.yaml
   - dev/lisp.yaml

--- a/test/radar/valid/dev/php.yaml
+++ b/test/radar/valid/dev/php.yaml
@@ -8,6 +8,10 @@ description: |
   Description
 rationale: |
   Rationale
+license:
+  open-source:
+    name: BSD-2 # Not completely true, but we want the test!
+    link: https://www.php.net/license/3_01.txt
 tags:
   - 90's
   - Web

--- a/test/radar/valid/dev/php.yaml
+++ b/test/radar/valid/dev/php.yaml
@@ -10,8 +10,9 @@ rationale: |
   Rationale
 license:
   open-source:
-    name: BSD-2 # Not completely true, but we want the test!
+    name: BSD-2
     link: https://www.php.net/license/3_01.txt
+    description: This is not really BSD-2, but let's use it for the test!
 tags:
   - 90's
   - Web

--- a/test/radarService.test.js
+++ b/test/radarService.test.js
@@ -72,7 +72,7 @@ describe('RadarService', () => {
 
   test('It can list unique tags', () => {
     const tags = radarService.listTags();
-    expect(tags).toHaveLength(8);
+    expect(tags).toHaveLength(9);
     expect(tags).toEqual([
       '90\'s',
       'bsd',
@@ -81,6 +81,7 @@ describe('RadarService', () => {
       'gpl-ce',
       'java',
       'open-source',
+      'oracle',
       'web',
     ]);
   });

--- a/test/radarService.test.js
+++ b/test/radarService.test.js
@@ -78,7 +78,7 @@ describe('RadarService', () => {
       'bsd',
       'bsd-2',
       'commercial',
-      'gpl-cpe',
+      'gpl-ce',
       'java',
       'open-source',
       'web',

--- a/test/radarService.test.js
+++ b/test/radarService.test.js
@@ -72,10 +72,17 @@ describe('RadarService', () => {
 
   test('It can list unique tags', () => {
     const tags = radarService.listTags();
-    expect(tags).toHaveLength(3);
-
-    tags.sort((a, b) => a.localeCompare(b));
-    expect(tags).toEqual(['90\'s', 'java', 'web']);
+    expect(tags).toHaveLength(8);
+    expect(tags).toEqual([
+      '90\'s',
+      'bsd',
+      'bsd-2',
+      'commercial',
+      'gpl-cpe',
+      'java',
+      'open-source',
+      'web',
+    ]);
   });
 
   test('It can list entries by tag', () => {

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -8,6 +8,21 @@ describe('YAML Reader', () => {
     expect(callback.mock.calls.length).toEqual(3);
   });
 
+  test('It maps licenses to tags', () => {
+    const entries = [];
+    reader.collectEntries(path.resolve(__dirname, 'radar/valid'), entry => entries.push(entry));
+    expect(entries.find(entry => entry.name === 'Java').tags).toEqual([
+      '90\'s',
+      'commercial',
+      'gpl-cpe',
+      'java',
+      'open-source',
+      'web',
+    ]);
+
+    expect(entries.find(entry => entry.name === 'PHP').tags).toContain('bsd');
+  });
+
   test('It throws error on invalid relations', () => {
     expect(
       () => reader.collectEntries(path.resolve(__dirname, 'radar/ref_error'), jest.fn()),

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -17,6 +17,7 @@ describe('YAML Reader', () => {
       'gpl-ce',
       'java',
       'open-source',
+      'oracle',
       'web',
     ]);
 

--- a/test/reader.test.js
+++ b/test/reader.test.js
@@ -14,7 +14,7 @@ describe('YAML Reader', () => {
     expect(entries.find(entry => entry.name === 'Java').tags).toEqual([
       '90\'s',
       'commercial',
-      'gpl-cpe',
+      'gpl-ce',
       'java',
       'open-source',
       'web',


### PR DESCRIPTION
This PR introduces support for license information in radar entries. The license information will be displayed on the entry information page and also included as tags for filtering.