### PR TITLE
feat: Improve blip archive feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,9 @@ The format of a blip is as follows:
 name: Entry name # Required
 logo: https://domain.com/logo.png # Optional logo URL
 shortname: Short # Optional. Use only if name is too long for the radar blip
-active: true # Optional. If set to `false`, the blip is hidden on the visual radar
 blip: # A list of blip positions. Add a new entry every time the blip moves
   - date: 2019-05-21 # Required. The date the blip is created or changed
-    ring: ASSESS # Required. The position at date, One of ADOPT, TRIAL, ASSESS, HOLD
+    ring: ASSESS # Required. The position at date, One of ADOPT, TRIAL, ASSESS, HOLD, ARCHIVE
   - date: 2019-05-25
     ring: ADOPT
 description: |

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -158,11 +158,6 @@ ul.history {
   color: white;
 }
 
-.badge.inactive {
-  background: #ff8f00;
-  color: white;
-}
-
 .badge.license {
   background: #fefefe;
   border: 1px solid #cfd8dc;
@@ -228,4 +223,16 @@ ul.tags {
 .entry-tag a {
   color: #333;
   text-decoration: none;
+}
+
+.inactive-note {
+  background: #ffb300;
+  color: black;
+  margin-bottom: 1em;
+  padding: 0.5em;
+}
+
+a.inactive {
+  color: gray;
+  text-decoration: line-through;
 }

--- a/src/js/builder/reader.js
+++ b/src/js/builder/reader.js
@@ -60,8 +60,11 @@ const createBlip = (entry) => {
     active: true,
   };
 
-  if (typeof entry.active !== 'undefined') {
-    blip.active = entry.active;
+  if (last(entry.blip).ring === 'ARCHIVE') {
+    blip.active = false;
+    const archiveRing = entry.blip[entry.blip.length - 2].ring;
+    blip.ring = radar.rings.indexOf(archiveRing);
+    blip.ringName = ringName(archiveRing);
   }
 
   if (entry.blip.length > 1) {

--- a/src/js/components/Entry.jsx
+++ b/src/js/components/Entry.jsx
@@ -10,6 +10,7 @@ import License from './entry/License';
 import Navigation from './Navigation';
 import NotFound from './NotFound';
 import LicenseBadges from './entry/LicenseBadges';
+import Icon from './Icon';
 
 const Entry = (props) => {
   const { match } = props;
@@ -25,6 +26,20 @@ const Entry = (props) => {
     <React.Fragment>
       <Navigation quadrant={quadrant} entry={{ name: entry.name }} />
       <div className="container">
+        {(entry.blip.active === false) && (
+          <div className="row">
+            <div className="twelve columns inactive-note">
+              <strong>
+                <Icon name="exclamation-triangle" />
+                Not active on the current version!
+              </strong>
+              <br />
+              This blip is not on the current version of the radar. If it was recently archived it
+              is likely that it is still relevant. If the blip is older it might no longer be
+              relevant or our assessment of it might be different today.
+            </div>
+          </div>
+        )}
         <div className="row">
           <div className="entry-container">
             <h1>{entry.name}</h1>
@@ -37,9 +52,6 @@ const Entry = (props) => {
           <div className="badges">
             <Badge className={entry.blip.ringName} icon="map-marker" text={entry.blip.ringName} />
             <Badge icon="clock-o" text={entry.blip.since} />
-            {(entry.blip.active === false) && (
-              <Badge className="inactive" icon="warning" text="Inactive" />
-            )}
             <LicenseBadges license={entry.license} />
           </div>
           <div className="twelve columns">

--- a/src/js/components/Quadrant.jsx
+++ b/src/js/components/Quadrant.jsx
@@ -18,7 +18,12 @@ export default class Quadrant extends Component {
     <ul className={ring}>
       { quadrant[ring].map(entry => (
         <li key={entry.filename}>
-          <Link to={`/entries/${entry.filename}`}>{entry.name}</Link>
+          <Link
+            to={`/entries/${entry.filename}`}
+            className={entry.active ? '' : 'inactive'}
+          >
+            {entry.name}
+          </Link>
         </li>
       ))}
     </ul>

--- a/src/js/modules/__mocks__/radarService.js
+++ b/src/js/modules/__mocks__/radarService.js
@@ -44,6 +44,7 @@ const mockEntries = {
       history: [
         { date: 'Jan 1, 1970', ringName: 'Adopt' },
         { date: 'Mar 20, 2018', ringName: 'Hold' },
+        { date: 'Aug 23, 2019', ringName: 'Archive' },
       ],
     },
     description: 'Description',
@@ -116,17 +117,17 @@ export default {
       name: 'Test',
       dirname: 'test1',
       adopt: [
-        { name: 'A - 1', filename: '1.html' },
-        { name: 'B - 2', filename: '2.html' },
+        { name: 'A - 1', filename: '1.html', active: true },
+        { name: 'B - 2', filename: '2.html', active: true },
       ],
       trial: [],
       assess: [
-        { name: 'C - 3', filename: '3.html' },
+        { name: 'C - 3', filename: '3.html', active: true },
       ],
       hold: [
-        { name: 'D - 4', filename: '4.html' },
-        { name: 'E - 5', filename: '5.html' },
-        { name: 'F - 6', filename: '6.html' },
+        { name: 'D - 4', filename: '4.html', active: true },
+        { name: 'E - 5', filename: '5.html', active: true },
+        { name: 'F - 6', filename: '6.html', active: false },
       ],
     };
   },

--- a/src/js/modules/radarService.js
+++ b/src/js/modules/radarService.js
@@ -40,8 +40,11 @@ class RadarService {
   listEntries = (quadrant, ring, active = true) => {
     const filters = [
       entry => entry.quadrant.dirname === quadrant,
-      entry => entry.blip.active === active,
     ];
+
+    if (active) {
+      filters.push(entry => entry.blip.active === active);
+    }
 
     if (ring !== '*') {
       filters.push(entry => entry.blip.ring === ring);
@@ -61,10 +64,13 @@ class RadarService {
     if (qi >= 0) {
       const quadrant = { ...this.model.quadrants[qi] };
       this.model.rings.forEach((ring, index) => {
-        quadrant[ring.toLowerCase()] = this.listEntries(quadrant.dirname, index)
-          .map(entry => pick(entry, 'name', 'filename'));
+        quadrant[ring.toLowerCase()] = this.listEntries(quadrant.dirname, index, false)
+          .map((entry) => {
+            const out = pick(entry, 'name', 'filename');
+            out.active = entry.blip.active;
+            return out;
+          });
       });
-      quadrant.inactive = this.listEntries(quadrant.dirname, '*', false);
       return quadrant;
     }
     return undefined;

--- a/src/radar_entry.schema.yaml
+++ b/src/radar_entry.schema.yaml
@@ -9,8 +9,6 @@ mapping:
     type: str
   "shortname":
     type: str
-  "active":
-    type: bool
   "blip":
     type: seq
     required: true
@@ -23,7 +21,7 @@ mapping:
           "ring":
             type: str
             required: true
-            enum: [ADOPT, TRIAL, ASSESS, HOLD]
+            enum: [ADOPT, TRIAL, ASSESS, HOLD, ARCHIVE]
   "description":
     type: str
     required: true

--- a/test/Entry.test.jsx
+++ b/test/Entry.test.jsx
@@ -25,10 +25,10 @@ describe('<Entry />', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('It renders inactive badge', () => {
+  test('It renders inactive statement', () => {
     const match = { params: { id: 'lisp' } };
     const component = shallow(<Entry match={match} />);
-    expect(component.find('.inactive')).toHaveLength(1);
+    expect(component.find('.inactive-note')).toHaveLength(1);
     expect(component).toMatchSnapshot();
   });
 

--- a/test/Quadrant.test.jsx
+++ b/test/Quadrant.test.jsx
@@ -28,4 +28,10 @@ describe('<Quadrant />', () => {
     expect(component.find(NotFound)).toHaveLength(1);
     expect(component).toMatchSnapshot();
   });
+
+  test('It renders inactive style for archived entries', () => {
+    const match = { params: { quadrant: 'test' } };
+    const component = shallow(<Quadrant match={match} />);
+    expect(component.find('.inactive')).toHaveLength(1);
+  });
 });

--- a/test/__snapshots__/Entry.test.jsx.snap
+++ b/test/__snapshots__/Entry.test.jsx.snap
@@ -260,7 +260,7 @@ exports[`<Entry /> It renders entry with related links 1`] = `
 </Fragment>
 `;
 
-exports[`<Entry /> It renders inactive badge 1`] = `
+exports[`<Entry /> It renders inactive statement 1`] = `
 <Fragment>
   <Navigation
     entry={
@@ -280,6 +280,23 @@ exports[`<Entry /> It renders inactive badge 1`] = `
   <div
     className="container"
   >
+    <div
+      className="row"
+    >
+      <div
+        className="twelve columns inactive-note"
+      >
+        <strong>
+          <Icon
+            name="exclamation-triangle"
+            spaceBefore={true}
+          />
+          Not active on the current version!
+        </strong>
+        <br />
+        This blip is not on the current version of the radar. If it was recently archived it is likely that it is still relevant. If the blip is older it might no longer be relevant or our assessment of it might be different today.
+      </div>
+    </div>
     <div
       className="row"
     >
@@ -308,12 +325,6 @@ exports[`<Entry /> It renders inactive badge 1`] = `
           icon="clock-o"
           link={null}
           text="Jan 1, 1970"
-        />
-        <Badge
-          className="inactive"
-          icon="warning"
-          link={null}
-          text="Inactive"
         />
         <LicenseBadges
           license={
@@ -373,6 +384,10 @@ exports[`<Entry /> It renders inactive badge 1`] = `
               Object {
                 "date": "Mar 20, 2018",
                 "ringName": "Hold",
+              },
+              Object {
+                "date": "Aug 23, 2019",
+                "ringName": "Archive",
               },
             ]
           }

--- a/test/__snapshots__/Quadrant.test.jsx.snap
+++ b/test/__snapshots__/Quadrant.test.jsx.snap
@@ -35,6 +35,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="1.html"
           >
             <Link
+              className=""
               to="/entries/1.html"
             >
               A - 1
@@ -44,6 +45,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="2.html"
           >
             <Link
+              className=""
               to="/entries/2.html"
             >
               B - 2
@@ -70,6 +72,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="3.html"
           >
             <Link
+              className=""
               to="/entries/3.html"
             >
               C - 3
@@ -86,6 +89,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="4.html"
           >
             <Link
+              className=""
               to="/entries/4.html"
             >
               D - 4
@@ -95,6 +99,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="5.html"
           >
             <Link
+              className=""
               to="/entries/5.html"
             >
               E - 5
@@ -104,6 +109,7 @@ exports[`<Quadrant /> It renders as expected 1`] = `
             key="6.html"
           >
             <Link
+              className="inactive"
               to="/entries/6.html"
             >
               F - 6

--- a/test/radar/valid/dev/lisp.yaml
+++ b/test/radar/valid/dev/lisp.yaml
@@ -1,11 +1,12 @@
 name: Common Lisp
 shortname: Lisp
-active: false
 blip:
   - date: 1970-01-01
     ring: ADOPT
   - date: 2018-03-20
     ring: HOLD
+  - date: 2019-08-23
+    ring: ARCHIVE
 description: |
   Description
 rationale: |

--- a/test/radarService.test.js
+++ b/test/radarService.test.js
@@ -35,12 +35,13 @@ describe('RadarService', () => {
     expect(quadrant).toMatchObject({
       dirname: 'dev',
       adopt: [
-        { name: 'Java', filename: 'java.html' },
+        { name: 'Java', filename: 'java.html', active: true },
       ],
       assess: [],
       trial: [],
       hold: [
-        { name: 'PHP', filename: 'php.html' },
+        { name: 'Common Lisp', filename: 'lisp.html', active: false },
+        { name: 'PHP', filename: 'php.html', active: true },
       ],
     });
   });
@@ -55,9 +56,9 @@ describe('RadarService', () => {
     expect(entries).toHaveLength(2);
   });
 
-  test('It can list all inactive entries in quadrant', () => {
+  test('It can list all active and inactive entries in quadrant', () => {
     const entries = radarService.listEntries('dev', '*', false);
-    expect(entries).toHaveLength(1);
+    expect(entries).toHaveLength(3);
   });
 
   test('It can list entries by quadrant and ring', () => {


### PR DESCRIPTION
This change modifies the archive functionality to be applied in the blip history. This means we can track when something is moved to/from archive in the blip history. The old `active` flag has been removed from the schema.

BREAKING CHANGE: The YAML schema no longer supports the `active` flag. Instead use the `ARCHIVE` ring type on blip level.