### PR TITLE
feat: Move Elasticsearch to TRIAL

### DIFF
--- a/radar/data_management/elasticsearch.yaml
+++ b/radar/data_management/elasticsearch.yaml
@@ -4,11 +4,16 @@ blip:
     ring: TRIAL
   - date: 2019-05-23
     ring: ADOPT
+  - date: 2020-06-15
+    ring: TRIAL
 description: |
   Elasticsearch is a distributed, massivily scalable search engine.
 rationale: |
   Consider Elasticsearch when there's a need to search massive amounts of
   data, for example in Retail Suite, Centraloffice, ASI or logging and tracing needs.
+
+  Elasticsearch should be used as a managed service (SaaS) for cloud services. We must
+  evaulate the licensing, operations and business case before we can adopt Elasticsearch.
 related:
   - data_management/kibana.yaml
   - data_management/beats.yaml

--- a/radar/qa/operations.yaml
+++ b/radar/qa/operations.yaml
@@ -4,8 +4,8 @@ blip:
   - date: 2020-05-06
     ring: TRIAL
 description: |
-  [Google Cloud’s operations suite](https://cloud.google.com/products/operations) (formerly Stackdriver) is designed to
-  monitor, troubleshoot, and improve cloud infrastructure, software, and application performance.
+  [Google Cloud’s operations suite](https://cloud.google.com/products/operations) (formerly Stackdriver) is designed
+  to monitor, troubleshoot, and improve cloud infrastructure, software, and application performance.
   Efficiently build and run workloads, keeping applications performant and available.
 rationale: |
   Operations suite gives us an easy way to monitor our workloads in GCP.


### PR DESCRIPTION
As discussed in the architecture chapter we will move Elasticsearch from ADOPT to TRIAL to evaluate operations, licensing and the business case.