### PR TITLE
feat: Archive log4net

### DIFF
--- a/radar/dev/log4net.yaml
+++ b/radar/dev/log4net.yaml
@@ -2,6 +2,8 @@ name: Log4net
 blip:
   - date: 2019-05-22
     ring: ADOPT
+  - date: 2020-06-24
+    ring: ARCHIVE
 description: |
   Log framework from Apache
 rationale:


### PR DESCRIPTION
Move log4net to archive. As discussed in the arch.chapter we will move low-level tech that doesn't need to be visible in the radar into the archive.