### PR TITLE
feat: Move ADR to TRIAL

### DIFF
--- a/radar/qa/decision_records.yaml
+++ b/radar/qa/decision_records.yaml
@@ -3,12 +3,14 @@ shortname: Arch. Decision Records
 blip:
   - date: 2020-05-06
     ring: ASSESS
+  - date: 2020-06-26
+    ring: TRIAL
 description: |
   [Architectural Decision Records (ADR)](https://adr.github.io/) captures
   a single Architecutral Decision and together forms a decision log.
 rationale: |
-  We should assess if ADR is a good way for us to document decisions taken.
-  The main rationale is that its an easy and common way to follow decisions
+  We use ADR as a way to document decisions taken related to architecture and technology.
+  The main rationale for doing this is that its an easy and common way to follow decisions
   and see the rationale behind that specific decision.
 
   Architectural Decision Records follows this syntax:
@@ -20,6 +22,9 @@ rationale: |
   accepting <downside d/undesired consequences>,
   because <additional rationale>.
   ````
+
+  We recommend using the [adr-tools](https://github.com/npryce/adr-tools) utility to create and maintain
+  ADRs in your GitHub repository.
 related:
   - qa/structurizr.yaml
 tags:


### PR DESCRIPTION
We now promote ADR for use with Hii Retail development process. Hence, time to move it to TRIAL.